### PR TITLE
Improve rule lookup performance

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,97 +1,83 @@
 {minimum_otp_vsn, "21.0"}.
 
 {alias, [
-         {check, [lint, xref, dialyzer, edoc,
-                  {eunit, "-c"}, {ct, "-c"}, {proper, "-c"},
-                  {cover, "-v --min_coverage=85"},
-                  todo
-                 ]}
-        ]}.
+    {check, [
+        lint,
+        xref,
+        dialyzer,
+        edoc,
+        {eunit, "-c"},
+        {ct, "-c"},
+        {proper, "-c"},
+        {cover, "-v --min_coverage=85"},
+        todo
+    ]}
+]}.
 
 {dialyzer, [{warnings, [unknown]}]}.
 
-{edoc_opts, []}.
+{edoc_opts, [
+    {app_default, "https://www.erlang.org/doc/man"},
+    {image, ""},
+    {preprocess, true},
+    {title, "robots"}
+]}.
+
 {erl_opts, [
-            debug_info,
-            warn_unused_import,
-            warnings_as_errors
-           ]}.
+    debug_info,
+    warn_unused_import,
+    warnings_as_errors
+]}.
 
-{deps, []
-}.
+{deps, []}.
 
-{profiles, [{prod, [{relx, [{dev_mode, false},
-                            {include_erts, true}]}]
-            },
+{profiles, [
+    {prod, [
+        {relx, [
+            {dev_mode, false},
+            {include_erts, true}
+        ]}
+    ]},
 
-            {test, [
-                    {erl_opts, [nowarn_export_all]},
-                    {deps, [
-                            {meck, "0.8.9"},
-                            {proper, {git, "https://github.com/manopapad/proper.git", {branch, "master"}}}
-                           ]}
-                   ]}
-           ]
-}.
+    {test, [
+        {erl_opts, [nowarn_export_all]},
+        {eunit_opts, [no_tty, {report, {unite_compact, []}}]},
+        {deps, [
+            {meck, "0.8.9"},
+            {proper, {git, "https://github.com/manopapad/proper.git", {branch, "master"}}},
+            {unite, {git, "git://github.com/eproxus/unite.git", {tag, "0.3.1"}}}
+        ]}
+    ]}
+]}.
 
 {plugins, [
-           {rebar3_proper, "0.11.1"},
-           {rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "0.1.2"}}},
-           {rebar3_todo, {git, "https://github.com/ferd/rebar3_todo.git", {branch, "master"}}},
-           rebar3_hex,
-           coveralls
-          ]}.
+    {rebar3_proper, "0.11.1"},
+    {rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "v0.4.0"}}},
+    {rebar3_todo, {git, "https://github.com/ferd/rebar3_todo.git", {branch, "master"}}},
+    rebar3_hex,
+    coveralls
+]}.
 
 {cover_enabled, true}.
+
 {cover_opts, [verbose]}.
+
 {cover_export_enabled, true}.
 
-{elvis,
- [#{dirs => ["apps/*/src/**",
-             "apps/*/test/**"],
-    filter => "*.erl",
-    rules => [{elvis_style, line_length,
-               #{ignore => [],
-                 limit => 120,
-                 skip_comments => false}},
-              {elvis_style, no_tabs},
-              {elvis_style, no_trailing_whitespace},
-              {elvis_style, macro_names, #{ignore => []}},
-              {elvis_style, macro_module_names},
-              {elvis_style, operator_spaces, #{rules => [{right, ","},
-                                                         {right, "++"},
-                                                         {left, "++"}]}},
-              {elvis_style, nesting_level, #{level => 3}},
-              {elvis_style, god_modules,
-               #{limit => 25,
-                 ignore => []}},
-              {elvis_style, no_if_expression},
-              {elvis_style, invalid_dynamic_call,
-               #{ignore => []}},
-              {elvis_style, used_ignored_variable},
-              {elvis_style, no_behavior_info},
-              {elvis_style,
-               module_naming_convention,
-               #{regex => "^[a-z]([a-z0-9]*_?)*(_SUITE)?$", ignore => []}},
-              {elvis_style,
-               function_naming_convention,
-               #{regex => "^[a-z]([a-z0-9]*_?)*$"}},
-              {elvis_style, state_record_and_type},
-              {elvis_style, no_spec_with_records},
-              {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
-              {elvis_style, no_debug_call, #{ignore => []}}
-             ]
-   },
-  #{dirs => ["."],
-    filter => "rebar.config",
-    rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}}]
-   }
- ]
-}.
+{elvis, [
+    #{
+        dirs => ["."],
+        filter => "rebar.config",
+        ruleset => rebar_config
+    }
+]}.
 
-{xref_checks,[undefined_function_calls,
-              undefined_functions,
-              locals_not_used,
-              deprecated_function_calls,
-              deprecated_functions]}.
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used,
+    deprecated_function_calls,
+    deprecated_functions
+]}.
+
 {xref_ignores, []}.

--- a/src/robots.erl
+++ b/src/robots.erl
@@ -84,11 +84,11 @@ find_agent_rules(<<>>, RulesIndex) ->
     end;
 find_agent_rules(Agent, RulesIndex) ->
     case maps:find(Agent, RulesIndex) of
-        Result = {ok, _} ->
-            Result;
         error ->
             <<_:1/binary, Rest/binary>> = Agent,
-            find_agent_rules(Rest, RulesIndex)
+            find_agent_rules(Rest, RulesIndex);
+        Result ->
+            Result
     end.
 
 -spec is_allowed(binary(), {ok, {rules(), rules()} | allowed_all()} | {error, term()}) -> boolean().

--- a/src/robots.erl
+++ b/src/robots.erl
@@ -1,5 +1,5 @@
 %% @author Antoine Gagné <gagnantoine@gmail.com>
-%% @copyright 2019 Antoine Gagné
+%% @copyright 2021 Antoine Gagné
 %% @doc Parse and manipulate robots.txt files according to the specification.
 -module(robots).
 
@@ -8,9 +8,11 @@
 -endif.
 
 %% API
--export([parse/2,
-         sitemap/1,
-         is_allowed/3]).
+-export([
+    parse/2,
+    sitemap/1,
+    is_allowed/3
+]).
 
 -export_type([agent_rules/0]).
 
@@ -21,9 +23,13 @@
 -type content() :: string() | binary().
 -type status() :: allowed | disallowed.
 -type allowed_all() :: {allowed, all}.
--type rules_index() :: #{agent() := {Allowed :: rules(), Disallowed :: rules()} | allowed_all(),
-                         sitemap => binary()}.
+-type rules_index() :: #{
+    agent() := {Allowed :: rules(), Disallowed :: rules()} | allowed_all(),
+    sitemap => binary()
+}.
+
 -type sitemap() :: binary().
+
 -opaque agent_rules() :: {status(), all} | rules_index().
 
 -define(ALL, <<"*">>).
@@ -51,7 +57,8 @@ is_allowed(_Agent, _Url, {allowed, all}) ->
 is_allowed(_Agent, _Url, {disallowed, all}) ->
     false;
 is_allowed(Agent, Url, RulesIndex) ->
-    MaybeRules = find_agent_rules(Agent, RulesIndex),
+    Reversed = reverse(Agent),
+    MaybeRules = find_agent_rules(Reversed, RulesIndex),
     is_allowed(Url, MaybeRules).
 
 -spec sitemap(agent_rules()) -> {ok, sitemap()} | {error, not_found}.
@@ -59,7 +66,7 @@ is_allowed(Agent, Url, RulesIndex) ->
 sitemap(RulesIndex) ->
     case maps:find(sitemap, RulesIndex) of
         error -> {error, not_found};
-        V={ok, _} -> V
+        V = {ok, _} -> V
     end.
 
 %%%===================================================================
@@ -70,22 +77,25 @@ sitemap(RulesIndex) ->
     {error, not_found} | {ok, {rules(), rules()} | allowed_all()}.
 find_agent_rules(<<>>, RulesIndex) ->
     case maps:find(?ALL, RulesIndex) of
-        error -> {error, not_found};
-        Result -> Result
+        error ->
+            {error, not_found};
+        Result ->
+            Result
     end;
 find_agent_rules(Agent, RulesIndex) ->
     case maps:find(Agent, RulesIndex) of
-        Result={ok, _} -> Result;
+        Result = {ok, _} ->
+            Result;
         error ->
-            Size = byte_size(Agent),
-            find_agent_rules(binary:part(Agent, 0, Size - 1), RulesIndex)
+            <<_:1/binary, Rest/binary>> = Agent,
+            find_agent_rules(Rest, RulesIndex)
     end.
 
 -spec is_allowed(binary(), {ok, {rules(), rules()} | allowed_all()} | {error, term()}) -> boolean().
 is_allowed(_Url, {ok, {allowed, all}}) ->
     true;
 is_allowed(Url, {ok, {Allowed, Disallowed}}) ->
-    Match = fun (Rule) -> match(Url, Rule) end,
+    Match = fun(Rule) -> match(Url, Rule) end,
     lists:any(Match, Allowed) orelse not lists:any(Match, Disallowed);
 is_allowed(_Url, {error, _}) ->
     true.
@@ -111,20 +121,20 @@ sanitize(Line) ->
 
 -spec handle_line(binary()) -> {true, {binary(), binary()}} | false.
 handle_line(Line) ->
-  case string:split(Line, ":") of
-      Split=[_, _ | _] ->
-          [Key, Value | _] = lists:map(fun trim/1, Split),
-          {true, {string:lowercase(Key), Value}};
-      _ ->
-          false
-  end.
+    case string:split(Line, ":") of
+        Split = [_, _ | _] ->
+            [Key, Value | _] = lists:map(fun trim/1, Split),
+            {true, {string:lowercase(Key), Value}};
+        _ ->
+            false
+    end.
 
 -spec sort_rules(agent() | sitemap, {[rule()], [rule()]} | allowed_all() | binary()) ->
     binary() | {[rule()], [rule()]}.
-sort_rules(_, Value={allowed, all}) ->
+sort_rules(_, Value = {allowed, all}) ->
     Value;
 sort_rules(_, {Allowed, Disallowed}) ->
-    Compare = fun (R1, R2) -> not (R1 =< R2) end,
+    Compare = fun(R1, R2) -> not (R1 =< R2) end,
     {lists:sort(Compare, Allowed), lists:sort(Compare, Disallowed)};
 sort_rules(sitemap, Value) ->
     Value.
@@ -136,9 +146,11 @@ trim(String) ->
 -spec build_rules({binary(), binary()}, {[agent()], boolean(), rules_index()}) ->
     {[agent()], boolean(), rules_index()}.
 build_rules({<<"user-agent">>, Agent}, {Agents, false, RulesIndex}) ->
-    {[Agent | Agents], false, RulesIndex};
+    Reversed = reverse(Agent),
+    {[Reversed | Agents], false, RulesIndex};
 build_rules({<<"user-agent">>, Agent}, {_Agents, true, RulesIndex}) ->
-    {[Agent], false, RulesIndex};
+    Reversed = reverse(Agent),
+    {[Reversed], false, RulesIndex};
 build_rules({<<"allow">>, Rule}, {Agents, _, RulesIndex}) ->
     {_, UpdatedIndex} = lists:foldl(fun update_index/2, {{allowed, Rule}, RulesIndex}, Agents),
     {Agents, true, UpdatedIndex};
@@ -155,16 +167,16 @@ build_rules({_Invalid, _Rule}, Acc) ->
 
 -spec update_index(agent(), {{status(), rule()}, rules_index()}) ->
     {{status(), rule()}, rules_index()}.
-update_index(Agent, {Rule={allowed, all}, RulesIndex}) ->
-    Update = fun (_) -> Rule end,
+update_index(Agent, {Rule = {allowed, all}, RulesIndex}) ->
+    Update = fun(_) -> Rule end,
     UpdatedIndex = maps:update_with(Agent, Update, Rule, RulesIndex),
     {Rule, UpdatedIndex};
 update_index(Agent, {{allowed, Rule}, RulesIndex}) ->
-    Update = fun ({Allowed, Disallowed}) -> {[Rule | Allowed], Disallowed} end,
+    Update = fun({Allowed, Disallowed}) -> {[Rule | Allowed], Disallowed} end,
     UpdatedIndex = maps:update_with(Agent, Update, {[Rule], []}, RulesIndex),
     {{allowed, Rule}, UpdatedIndex};
 update_index(Agent, {{disallowed, Rule}, RulesIndex}) ->
-    Update = fun ({Allowed, Disallowed}) -> {Allowed, [Rule | Disallowed]} end,
+    Update = fun({Allowed, Disallowed}) -> {Allowed, [Rule | Disallowed]} end,
     UpdatedIndex = maps:update_with(Agent, Update, {[], [Rule]}, RulesIndex),
     {{disallowed, Rule}, UpdatedIndex}.
 
@@ -187,12 +199,19 @@ match(_, <<>>) ->
     true;
 match(<<A, R1/binary>>, <<$*, A, R2/binary>>) ->
     match(R1, R2);
-match(<<_, R1/binary>>, <<$*, _, _/binary>>=R2) ->
+match(<<_, R1/binary>>, <<$*, _, _/binary>> = R2) ->
     match(R1, R2);
 match(<<A, R1/binary>>, <<A, R2/binary>>) ->
     match(R1, R2);
 match(<<_, _/binary>>, <<_, _/binary>>) ->
     false.
+
+%% Taken from: https://stackoverflow.com/a/43310493
+-spec reverse(binary()) -> binary().
+reverse(Binary) ->
+    Size = bit_size(Binary),
+    <<X:Size/integer-little>> = Binary,
+    <<X:Size/integer-big>>.
 
 %%%===================================================================
 %%% EUnit Tests
@@ -202,93 +221,110 @@ match(<<_, _/binary>>, <<_, _/binary>>) ->
 simple_path_test_() ->
     Rule = <<"/fish">>,
     [
-     ?_assert(match(<<"/fish">>, Rule)),
-     ?_assert(match(<<"/fish.html">>, Rule)),
-     ?_assert(match(<<"/fish/salmon.html">>, Rule)),
-     ?_assert(match(<<"/fishheads">>, Rule)),
-     ?_assert(match(<<"/fishheads/yummy.html">>, Rule)),
-     ?_assert(match(<<"/fish.php?id=anything">>, Rule)),
+        ?_assert(match(<<"/fish">>, Rule)),
+        ?_assert(match(<<"/fish.html">>, Rule)),
+        ?_assert(match(<<"/fish/salmon.html">>, Rule)),
+        ?_assert(match(<<"/fishheads">>, Rule)),
+        ?_assert(match(<<"/fishheads/yummy.html">>, Rule)),
+        ?_assert(match(<<"/fish.php?id=anything">>, Rule)),
 
-     ?_assertNot(match(<<"/Fish.asp">>, Rule)),
-     ?_assertNot(match(<<"/catfish">>, Rule)),
-     ?_assertNot(match(<<"/?id=fish">>, Rule))
+        ?_assertNot(match(<<"/Fish.asp">>, Rule)),
+        ?_assertNot(match(<<"/catfish">>, Rule)),
+        ?_assertNot(match(<<"/?id=fish">>, Rule))
     ].
 
 trailing_wildcard_test_() ->
     Rule = <<"/fish*">>,
     [
-     ?_assert(match(<<"/fish">>, Rule)),
-     ?_assert(match(<<"/fish.html">>, Rule)),
-     ?_assert(match(<<"/fish/salmon.html">>, Rule)),
-     ?_assert(match(<<"/fishheads">>, Rule)),
-     ?_assert(match(<<"/fishheads/yummy.html">>, Rule)),
-     ?_assert(match(<<"/fish.php?id=anything">>, Rule)),
+        ?_assert(match(<<"/fish">>, Rule)),
+        ?_assert(match(<<"/fish.html">>, Rule)),
+        ?_assert(match(<<"/fish/salmon.html">>, Rule)),
+        ?_assert(match(<<"/fishheads">>, Rule)),
+        ?_assert(match(<<"/fishheads/yummy.html">>, Rule)),
+        ?_assert(match(<<"/fish.php?id=anything">>, Rule)),
 
-     ?_assertNot(match(<<"/Fish.asp">>, Rule)),
-     ?_assertNot(match(<<"/catfish">>, Rule)),
-     ?_assertNot(match(<<"/?id=fish">>, Rule))
+        ?_assertNot(match(<<"/Fish.asp">>, Rule)),
+        ?_assertNot(match(<<"/catfish">>, Rule)),
+        ?_assertNot(match(<<"/?id=fish">>, Rule))
     ].
 
 trailing_slash_test_() ->
     Rule = <<"/fish/">>,
     [
-     ?_assert(match(<<"/fish/">>, Rule)),
-     ?_assert(match(<<"/fish/?id=anything">>, Rule)),
-     ?_assert(match(<<"/fish/salmon.htm">>, Rule)),
+        ?_assert(match(<<"/fish/">>, Rule)),
+        ?_assert(match(<<"/fish/?id=anything">>, Rule)),
+        ?_assert(match(<<"/fish/salmon.htm">>, Rule)),
 
-     ?_assertNot(match(<<"/fish">>, Rule)),
-     ?_assertNot(match(<<"/fish.html">>, Rule)),
-     ?_assertNot(match(<<"/Fish/Salmon.asp">>, Rule))
+        ?_assertNot(match(<<"/fish">>, Rule)),
+        ?_assertNot(match(<<"/fish.html">>, Rule)),
+        ?_assertNot(match(<<"/Fish/Salmon.asp">>, Rule))
     ].
 
 nested_wildcard_test_() ->
     Rule = <<"/*.php">>,
     [
-     ?_assert(match(<<"/filename.php">>, Rule)),
-     ?_assert(match(<<"/folder/filename.php">>, Rule)),
-     ?_assert(match(<<"/folder/filename.php?parameters">>, Rule)),
-     ?_assert(match(<<"/folder/any.php.file.html">>, Rule)),
-     ?_assert(match(<<"/filename.php/">>, Rule)),
+        ?_assert(match(<<"/filename.php">>, Rule)),
+        ?_assert(match(<<"/folder/filename.php">>, Rule)),
+        ?_assert(match(<<"/folder/filename.php?parameters">>, Rule)),
+        ?_assert(match(<<"/folder/any.php.file.html">>, Rule)),
+        ?_assert(match(<<"/filename.php/">>, Rule)),
 
-     ?_assertNot(match(<<"/">>, Rule)),
-     ?_assertNot(match(<<"/windows.PHP">>, Rule))
+        ?_assertNot(match(<<"/">>, Rule)),
+        ?_assertNot(match(<<"/windows.PHP">>, Rule))
     ].
 
 nested_wilcard_with_ending_test_() ->
     Rule = <<"/*.php$">>,
     [
-     ?_assert(match(<<"/filename.php">>, Rule)),
-     ?_assert(match(<<"/folder/filename.php">>, Rule)),
+        ?_assert(match(<<"/filename.php">>, Rule)),
+        ?_assert(match(<<"/folder/filename.php">>, Rule)),
 
-     ?_assertNot(match(<<"/filename.php?parameters">>, Rule)),
-     ?_assertNot(match(<<"/filename.php/">>, Rule)),
-     ?_assertNot(match(<<"/filename.php5">>, Rule)),
-     ?_assertNot(match(<<"/windows.PHP">>, Rule))
+        ?_assertNot(match(<<"/filename.php?parameters">>, Rule)),
+        ?_assertNot(match(<<"/filename.php/">>, Rule)),
+        ?_assertNot(match(<<"/filename.php5">>, Rule)),
+        ?_assertNot(match(<<"/windows.PHP">>, Rule))
     ].
 
 simple_path_with_nested_wildcard_test_() ->
     Rule = <<"/fish*.php">>,
     [
-     ?_assert(match(<<"/fish.php">>, Rule)),
-     ?_assert(match(<<"/fishheads/catfish.php?parameters">>, Rule)),
+        ?_assert(match(<<"/fish.php">>, Rule)),
+        ?_assert(match(<<"/fishheads/catfish.php?parameters">>, Rule)),
 
-     ?_assertNot(match(<<"/Fish.PHP">>, Rule))
+        ?_assertNot(match(<<"/Fish.PHP">>, Rule))
     ].
 
 user_agent_matching_test_() ->
     News = <<"/news">>,
     All = <<"/all">>,
     Generic = <<"/generic">>,
-    RulesIndex = #{<<"googlebot-news">> => {[News], []},
-                   <<"*">> => {[All], []},
-                   <<"googlebot">> => {[Generic], []}},
+    RulesIndex = #{
+        reverse(<<"googlebot-news">>) => {[News], []},
+        <<"*">> => {[All], []},
+        reverse(<<"googlebot">>) => {[Generic], []}
+    },
     [
-     ?_assertMatch({ok, {[News], []}}, find_agent_rules(<<"googlebot-news/1.0.0">>, RulesIndex)),
-     ?_assertMatch({ok, {[Generic], []}}, find_agent_rules(<<"googlebot-web*">>, RulesIndex)),
-     ?_assertMatch({ok, {[Generic], []}}, find_agent_rules(<<"googlebot-images*">>, RulesIndex)),
-     ?_assertMatch({ok, {[All], []}}, find_agent_rules(<<"otherbot-web/1.2.0">>, RulesIndex)),
-     ?_assertMatch({ok, {[All], []}}, find_agent_rules(<<"otherbot-news/1.2.0">>, RulesIndex)),
+        ?_assertEqual(
+            {ok, {[News], []}},
+            find_agent_rules(reverse(<<"googlebot-news/1.0.0">>), RulesIndex)
+        ),
+        ?_assertEqual(
+            {ok, {[Generic], []}},
+            find_agent_rules(reverse(<<"googlebot-web*">>), RulesIndex)
+        ),
+        ?_assertEqual(
+            {ok, {[Generic], []}},
+            find_agent_rules(reverse(<<"googlebot-images*">>), RulesIndex)
+        ),
+        ?_assertEqual(
+            {ok, {[All], []}},
+            find_agent_rules(reverse(<<"otherbot-web/1.2.0">>), RulesIndex)
+        ),
+        ?_assertEqual(
+            {ok, {[All], []}},
+            find_agent_rules(reverse(<<"otherbot-news/1.2.0">>), RulesIndex)
+        ),
 
-     ?_assertMatch({error, not_found}, find_agent_rules(<<"non-existent/1.0.0">>, #{}))
+        ?_assertEqual({error, not_found}, find_agent_rules(reverse(<<"non-existent/1.0.0">>), #{}))
     ].
 -endif.

--- a/test/robots_SUITE.erl
+++ b/test/robots_SUITE.erl
@@ -11,6 +11,7 @@
 -define(CODE_5XX, 514).
 -define(EMPTY_CONTENT, <<>>).
 -define(USER_AGENT, <<"bot/1.0.0">>).
+-define(REVERSED_USER_AGENT, <<"0.0.1/tob">>).
 -define(NON_EXISTENT_USER_AGENT, <<"nonexistent/1.0.0">>).
 -define(AN_URL, <<"/bot-url">>).
 -define(A_MATCHING_URL, <<"/foo/">>).
@@ -19,9 +20,11 @@
 -define(ANOTHER_RULE, <<"/bar">>).
 -define(A_VALID_CODE, 200).
 -define(A_VALID_CONTENT, <<"User-Agent: ", ?USER_AGENT/binary, "\nAllow: ", ?A_RULE/binary>>).
--define(ANOTHER_VALID_CONTENT, <<"User-Agent: ", ?USER_AGENT/binary,
-                                 "\nAllow: ", ?A_RULE/binary,
-                                 "\nDisallow: ", ?ANOTHER_RULE/binary>>).
+-define(ANOTHER_VALID_CONTENT,
+    <<"User-Agent: ", ?USER_AGENT/binary, "\nAllow: ", ?A_RULE/binary, "\nDisallow: ",
+        ?ANOTHER_RULE/binary>>
+).
+
 -define(A_VALID_CONTENT_WITH_COMMENT, <<?A_VALID_CONTENT/binary, "# this is a comment">>).
 -define(A_MALFORMED_CONTENT, <<"User-Agent: ", ?USER_AGENT/binary, "\n", ?A_RULE/binary>>).
 -define(SITEMAP, <<"http://somesitemap.com/map.xml">>).
@@ -60,47 +63,71 @@ return_error_on_unsupported_status_code(_Config) ->
 
 allow_all_on_4xx_code() ->
     [{doc, "Given a 4XX status code, when parsing, then returns all allowed."}].
+
 allow_all_on_4xx_code(_Config) ->
     ?assertMatch({ok, {allowed, all}}, robots:parse(?EMPTY_CONTENT, ?CODE_4XX)).
 
 disallow_all_on_5xx() ->
     [{doc, "Given a 5XX status code, when parsing, then returns all disallowed."}].
+
 disallow_all_on_5xx(_Config) ->
     ?assertMatch({ok, {disallowed, all}}, robots:parse(?EMPTY_CONTENT, ?CODE_5XX)).
 
 return_true_if_everything_is_allowed() ->
-    [{doc, "Given a set of rules that specifies that everything is allowed, "
-      "when checking if allowed, then returns true."}].
+    [
+        {doc,
+            "Given a set of rules that specifies that everything is allowed, "
+            "when checking if allowed, then returns true."}
+    ].
+
 return_true_if_everything_is_allowed(_Config) ->
     ?assert(robots:is_allowed(?USER_AGENT, ?AN_URL, {allowed, all})).
 
 return_false_if_everything_is_disallowed() ->
-    [{doc, "Given a set of rules that specifies that everything is allowed, "
-      "when checking if allowed, then returns false."}].
+    [
+        {doc,
+            "Given a set of rules that specifies that everything is allowed, "
+            "when checking if allowed, then returns false."}
+    ].
+
 return_false_if_everything_is_disallowed(_Config) ->
     ?assertNot(robots:is_allowed(?USER_AGENT, ?AN_URL, {disallowed, all})).
 
 can_parse_valid_robots_txt() ->
     [{doc, "Given a valid robots.txt content, when parsing, then returns all rules."}].
+
 can_parse_valid_robots_txt(_Config) ->
-    ?assertMatch({ok, #{?USER_AGENT := {[?A_RULE], []}}},
-                 robots:parse(?A_VALID_CONTENT, ?A_VALID_CODE)).
+    ?assertMatch(
+        {ok, #{?REVERSED_USER_AGENT := {[?A_RULE], []}}},
+        robots:parse(?A_VALID_CONTENT, ?A_VALID_CODE)
+    ).
 
 can_parse_valid_non_binary_robots_txt() ->
-    [{doc, "Given a valid robots.txt content in non-binary format, when parsing, "
-      "then returns all rules."}].
+    [
+        {doc,
+            "Given a valid robots.txt content in non-binary format, when parsing, "
+            "then returns all rules."}
+    ].
+
 can_parse_valid_non_binary_robots_txt(_Config) ->
     NonBinary = unicode:characters_to_list(?A_VALID_CONTENT),
-    ?assertMatch({ok, #{?USER_AGENT := {[?A_RULE], []}}}, robots:parse(NonBinary, ?A_VALID_CODE)).
+    ?assertMatch(
+        {ok, #{?REVERSED_USER_AGENT := {[?A_RULE], []}}},
+        robots:parse(NonBinary, ?A_VALID_CODE)
+    ).
 
 can_handle_malformed_content() ->
     [{doc, "Given a malformed content, when parsing, then ignores the malformed part."}].
+
 can_handle_malformed_content(_Config) ->
-    ?assertMatch({ok, _},
-                 robots:parse(?A_MALFORMED_CONTENT, ?A_VALID_CODE)).
+    ?assertMatch(
+        {ok, _},
+        robots:parse(?A_MALFORMED_CONTENT, ?A_VALID_CODE)
+    ).
 
 can_fetch_sitemap() ->
     [{doc, "Given content with sitemap, when parsing, then returns the sitemap."}].
+
 can_fetch_sitemap(_Config) ->
     {ok, RulesIndex} = robots:parse(?CONTENT_WITH_SITEMAP, ?A_VALID_CODE),
 
@@ -108,51 +135,77 @@ can_fetch_sitemap(_Config) ->
 
 return_error_on_non_existent_sitemap() ->
     [{doc, "Given content without sitemap, when parsing, then returns an error."}].
+
 return_error_on_non_existent_sitemap(_Config) ->
     {ok, RulesIndex} = robots:parse(?A_VALID_CONTENT, ?A_VALID_CODE),
 
     ?assertMatch({error, not_found}, robots:sitemap(RulesIndex)).
 
 allow_all_on_unmatched_agents_at_end_of_file() ->
-    [{doc, "Given unmatched agents at the end of the file, when parsing, "
-      "then allows everything for those agents."}].
+    [
+        {doc,
+            "Given unmatched agents at the end of the file, when parsing, "
+            "then allows everything for those agents."}
+    ].
+
 allow_all_on_unmatched_agents_at_end_of_file(_Config) ->
-    ?assertMatch({ok, #{?USER_AGENT := {allowed, all}}},
-                 robots:parse(<<"User-Agent: ", ?USER_AGENT/binary>>, ?A_VALID_CODE)).
+    ?assertMatch(
+        {ok, #{?REVERSED_USER_AGENT := {allowed, all}}},
+        robots:parse(<<"User-Agent: ", ?USER_AGENT/binary>>, ?A_VALID_CODE)
+    ).
 
 ignore_inline_comments() ->
     [{doc, "Given a rule with a comment in it, when parsing, then ignores the comment."}].
+
 ignore_inline_comments(_Config) ->
-    ?assertMatch({ok, #{?USER_AGENT := {[?A_RULE], []}}},
-                 robots:parse(?A_VALID_CONTENT_WITH_COMMENT, ?A_VALID_CODE)).
+    ?assertMatch(
+        {ok, #{?REVERSED_USER_AGENT := {[?A_RULE], []}}},
+        robots:parse(?A_VALID_CONTENT_WITH_COMMENT, ?A_VALID_CODE)
+    ).
 
 return_true_if_agent_is_allowed() ->
-    [{doc, "Given a rules index with allowed URL for the corresponding agent, "
-      "when checking if allowed, then returns true."}].
+    [
+        {doc,
+            "Given a rules index with allowed URL for the corresponding agent, "
+            "when checking if allowed, then returns true."}
+    ].
+
 return_true_if_agent_is_allowed(_Config) ->
     {ok, RulesIndex} = robots:parse(?ANOTHER_VALID_CONTENT, ?A_VALID_CODE),
 
     ?assert(robots:is_allowed(?USER_AGENT, ?A_MATCHING_URL, RulesIndex)).
 
 return_false_if_agent_is_disallowed() ->
-    [{doc, "Given a rules index with disallowed URL for the corresponding agent, "
-      "when checking if allowed, then returns false."}].
+    [
+        {doc,
+            "Given a rules index with disallowed URL for the corresponding agent, "
+            "when checking if allowed, then returns false."}
+    ].
+
 return_false_if_agent_is_disallowed(_Config) ->
     {ok, RulesIndex} = robots:parse(?ANOTHER_VALID_CONTENT, ?A_VALID_CODE),
 
     ?assertNot(robots:is_allowed(?USER_AGENT, ?ANOTHER_MATCHING_URL, RulesIndex)).
 
 return_true_if_no_matching_rules_can_be_found() ->
-    [{doc, "Given a rules index with no matching agent, when checking if allowed, "
-      "then returns true."}].
+    [
+        {doc,
+            "Given a rules index with no matching agent, when checking if allowed, "
+            "then returns true."}
+    ].
+
 return_true_if_no_matching_rules_can_be_found(_Config) ->
     {ok, RulesIndex} = robots:parse(?ANOTHER_VALID_CONTENT, ?A_VALID_CODE),
 
     ?assert(robots:is_allowed(?NON_EXISTENT_USER_AGENT, ?ANOTHER_MATCHING_URL, RulesIndex)).
 
 return_true_if_everything_is_allowed_for_the_corresponding_agent() ->
-    [{doc, "Given a rules index with an agent for which everything is allowed, "
-      "when checking if allowed, then returns true."}].
+    [
+        {doc,
+            "Given a rules index with an agent for which everything is allowed, "
+            "when checking if allowed, then returns true."}
+    ].
+
 return_true_if_everything_is_allowed_for_the_corresponding_agent(_Config) ->
     {ok, RulesIndex} = robots:parse(<<"User-Agent: ", ?USER_AGENT/binary>>, ?A_VALID_CODE),
 

--- a/test/robots_SUITE.erl
+++ b/test/robots_SUITE.erl
@@ -28,33 +28,33 @@
 -define(CONTENT_WITH_SITEMAP, <<"Sitemap:", ?SITEMAP/binary>>).
 
 all() ->
+    [{group, all}].
+
+groups() ->
     [
-     return_error_on_unsupported_status_code,
-     allow_all_on_4xx_code,
-     disallow_all_on_5xx,
-     return_true_if_everything_is_allowed,
-     return_false_if_everything_is_disallowed,
-     can_parse_valid_robots_txt,
-     can_parse_valid_non_binary_robots_txt,
-     can_handle_malformed_content,
-     can_fetch_sitemap,
-     return_error_on_non_existent_sitemap,
-     allow_all_on_unmatched_agents_at_end_of_file,
-     ignore_inline_comments,
-     return_true_if_agent_is_allowed,
-     return_false_if_agent_is_disallowed,
-     return_true_if_no_matching_rules_can_be_found,
-     return_true_if_everything_is_allowed_for_the_corresponding_agent
+        {all, [parallel], [
+            return_error_on_unsupported_status_code,
+            allow_all_on_4xx_code,
+            disallow_all_on_5xx,
+            return_true_if_everything_is_allowed,
+            return_false_if_everything_is_disallowed,
+            can_parse_valid_robots_txt,
+            can_parse_valid_non_binary_robots_txt,
+            can_handle_malformed_content,
+            can_fetch_sitemap,
+            return_error_on_non_existent_sitemap,
+            allow_all_on_unmatched_agents_at_end_of_file,
+            ignore_inline_comments,
+            return_true_if_agent_is_allowed,
+            return_false_if_agent_is_disallowed,
+            return_true_if_no_matching_rules_can_be_found,
+            return_true_if_everything_is_allowed_for_the_corresponding_agent
+        ]}
     ].
-
-init_per_testcase(_Name, Config) ->
-    Config.
-
-end_per_testcase(_Name, Config) ->
-    Config.
 
 return_error_on_unsupported_status_code() ->
     [{doc, "Given an unsupported status code, when parsing, then returns an error."}].
+
 return_error_on_unsupported_status_code(_Config) ->
     ?assertMatch({error, _}, robots:parse(?EMPTY_CONTENT, ?UNSUPPORTED_CODE)).
 

--- a/test/robots_integration_SUITE.erl
+++ b/test/robots_integration_SUITE.erl
@@ -11,7 +11,7 @@
 
 all() ->
     [
-     can_parse_valid_robots_txt
+        can_parse_valid_robots_txt
     ].
 
 init_per_suite(Config) ->
@@ -30,11 +30,14 @@ end_per_testcase(_Name, Config) ->
 
 can_parse_valid_robots_txt() ->
     [{doc, "Given a valid robots.txt, when parsing, then returns valid rules index."}].
+
 can_parse_valid_robots_txt(Config) ->
     Valid = ?config(valid, Config),
 
-    ?assertMatch({ok, #{<<"Twitterbot">> := {[<<"/imgres">>], []}}},
-                 robots:parse(Valid, ?A_VALID_CODE)).
+    ?assertMatch(
+        {ok, #{<<"tobrettiwT">> := {[<<"/imgres">>], []}}},
+        robots:parse(Valid, ?A_VALID_CODE)
+    ).
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Previously, it used to do a lookup by removing the last character of the agent one by one until it found a match. This is really inefficient since we had to compute the size of the binary every time.

Instead, we now reverse the agents before storing and we remove the first character one by one instead of the last.