### PR TITLE
Normalize user agents

### DIFF
--- a/src/robots.erl
+++ b/src/robots.erl
@@ -56,9 +56,9 @@ is_allowed(_Agent, _Url, {allowed, all}) ->
     true;
 is_allowed(_Agent, _Url, {disallowed, all}) ->
     false;
-is_allowed(Agent, Url, RulesIndex) ->
-    Reversed = reverse(Agent),
-    MaybeRules = find_agent_rules(Reversed, RulesIndex),
+is_allowed(RawAgent, Url, RulesIndex) ->
+    Agent = to_agent(RawAgent),
+    MaybeRules = find_agent_rules(Agent, RulesIndex),
     is_allowed(Url, MaybeRules).
 
 -spec sitemap(agent_rules()) -> {ok, sitemap()} | {error, not_found}.
@@ -145,11 +145,11 @@ trim(String) ->
 
 -spec build_rules({binary(), binary()}, {[agent()], boolean(), rules_index()}) ->
     {[agent()], boolean(), rules_index()}.
-build_rules({<<"user-agent">>, Agent}, {Agents, false, RulesIndex}) ->
-    Reversed = reverse(Agent),
+build_rules({<<"user-agent">>, RawAgent}, {Agents, false, RulesIndex}) ->
+    Reversed = to_agent(RawAgent),
     {[Reversed | Agents], false, RulesIndex};
-build_rules({<<"user-agent">>, Agent}, {_Agents, true, RulesIndex}) ->
-    Reversed = reverse(Agent),
+build_rules({<<"user-agent">>, RawAgent}, {_Agents, true, RulesIndex}) ->
+    Reversed = to_agent(RawAgent),
     {[Reversed], false, RulesIndex};
 build_rules({<<"allow">>, Rule}, {Agents, _, RulesIndex}) ->
     {_, UpdatedIndex} = lists:foldl(fun update_index/2, {{allowed, Rule}, RulesIndex}, Agents),
@@ -205,6 +205,11 @@ match(<<A, R1/binary>>, <<A, R2/binary>>) ->
     match(R1, R2);
 match(<<_, _/binary>>, <<_, _/binary>>) ->
     false.
+
+-spec to_agent(Raw :: binary()) -> unicode:chardata().
+to_agent(Raw) ->
+    Reversed = reverse(Raw),
+    string:lowercase(Reversed).
 
 %% Taken from: https://stackoverflow.com/a/43310493
 -spec reverse(binary()) -> binary().

--- a/test/robots_SUITE.erl
+++ b/test/robots_SUITE.erl
@@ -55,6 +55,7 @@ groups() ->
             allow_all_on_unmatched_agents_at_end_of_file,
             ignore_inline_comments,
             return_true_if_agent_is_allowed,
+            match_independently_of_the_casing_of_the_agent,
             return_false_if_agent_is_disallowed,
             return_true_if_no_matching_rules_can_be_found,
             return_true_if_everything_is_allowed_for_the_corresponding_agent
@@ -191,6 +192,18 @@ return_true_if_agent_is_allowed(_Config) ->
     {ok, RulesIndex} = robots:parse(?ANOTHER_VALID_CONTENT, ?A_VALID_CODE),
 
     ?assert(robots:is_allowed(?USER_AGENT, ?A_MATCHING_URL, RulesIndex)).
+
+match_independently_of_the_casing_of_the_agent() ->
+    [
+        {doc,
+            "Given a rules index with allowed URL for the corresponding agent, "
+            "when checking if allowed with the allowed agent in different casing, "
+            "then returns true."}
+    ].
+match_independently_of_the_casing_of_the_agent(_Config) ->
+    {ok, RulesIndex} = robots:parse(?ANOTHER_VALID_CONTENT, ?A_VALID_CODE),
+
+    ?assert(robots:is_allowed(string:uppercase(?USER_AGENT), ?A_MATCHING_URL, RulesIndex)).
 
 return_false_if_agent_is_disallowed() ->
     [

--- a/test/robots_integration_SUITE.erl
+++ b/test/robots_integration_SUITE.erl
@@ -35,7 +35,7 @@ can_parse_valid_robots_txt(Config) ->
     Valid = ?config(valid, Config),
 
     ?assertMatch(
-        {ok, #{<<"tobrettiwT">> := {[<<"/imgres">>], []}}},
+        {ok, #{<<"tobrettiwt">> := {[<<"/imgres">>], []}}},
         robots:parse(Valid, ?A_VALID_CODE)
     ).
 


### PR DESCRIPTION
As mentioned in #12, the [specification](https://www.rfc-editor.org/rfc/rfc9309.html#name-the-user-agent-line) says that crawler names must be case insensitive.